### PR TITLE
Add support for reading the git config

### DIFF
--- a/src/Command/Config/Get.php
+++ b/src/Command/Config/Get.php
@@ -1,0 +1,55 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianFeldmann\Git\Command\Config;
+
+use SebastianFeldmann\Git\Command\Base;
+
+/**
+ * Class GetStagedFiles
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 0.9.0
+ */
+class Get extends Base
+{
+    /**
+     * The name of the configuration key to get
+     *
+     * @var string
+     */
+    private $name;
+
+    /**
+     * The name of the configuration key to get.
+     *
+     * @param string $name
+     *
+     * @return \SebastianFeldmann\Git\Command\Config\Get
+     */
+    public function name(string $name) : Get
+    {
+        $this->name = $name;
+
+        return $this;
+    }
+
+    /**
+     * Return the command to execute.
+     *
+     * @return string
+     * @throws \RuntimeException
+     */
+    protected function getGitCommand() : string
+    {
+        return 'config --get '.  escapeshellarg($this->name);
+    }
+}

--- a/src/Operator/Config.php
+++ b/src/Operator/Config.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ * This file is part of CaptainHook.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian.feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Operator;
+
+use SebastianFeldmann\Git\Command\Config\Get;
+use SebastianFeldmann\Git\Command\Config\ListAll;
+
+/**
+ * Class Config
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 0.9.0
+ */
+class Config extends Base
+{
+    /**
+     * If git has a configuration key
+     *
+     * @param  string $name
+     *
+     * @return boolean
+     */
+    public function has(string $name): bool
+    {
+        $result = $this->configCommand($name);
+
+        return $result->isSuccessful();
+    }
+
+
+    /**
+     * Get a configuration key value
+     *
+     * @param  string $name
+     *
+     * @return string
+     */
+    public function get(string $name): string
+    {
+        $result = $this->configCommand($name);
+
+        return $result->getBufferedOutput();
+    }
+
+    /**
+     * @param string $name
+     *
+     * @return \SebastianFeldmann\Cli\Command\Runner\Result
+     */
+    private function configCommand(string $name)
+    {
+        $cmd = (new Get($this->repo->getRoot()));
+        $cmd->name($name);
+
+        $result = $this->runner->run($cmd);
+
+        return $result;
+    }
+}

--- a/src/Repository.php
+++ b/src/Repository.php
@@ -7,6 +7,7 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  */
+
 namespace SebastianFeldmann\Git;
 
 use SebastianFeldmann\Cli\Command\Runner;
@@ -64,12 +65,12 @@ class Repository
     {
         $path = empty($root) ? getcwd() : realpath($root);
         // check for existing .git dir
-        if (!is_dir($path . DIRECTORY_SEPARATOR . '.git')) {
+        if (!is_dir($path.DIRECTORY_SEPARATOR.'.git')) {
             throw new \RuntimeException(sprintf('Invalid git repository: %s', $root));
         }
-        $this->root      = $path;
-        $this->dotGitDir = $this->root . DIRECTORY_SEPARATOR . '.git';
-        $this->runner    = null == $runner ? new Runner\Simple() : $runner;
+        $this->root = $path;
+        $this->dotGitDir = $this->root.DIRECTORY_SEPARATOR.'.git';
+        $this->runner = null == $runner ? new Runner\Simple() : $runner;
     }
 
     /**
@@ -77,7 +78,7 @@ class Repository
      *
      * @return string
      */
-    public function getRoot() : string
+    public function getRoot(): string
     {
         return $this->root;
     }
@@ -87,20 +88,21 @@ class Repository
      *
      * @return string
      */
-    public function getHooksDir() : string
+    public function getHooksDir(): string
     {
-        return $this->dotGitDir . DIRECTORY_SEPARATOR . 'hooks';
+        return $this->dotGitDir.DIRECTORY_SEPARATOR.'hooks';
     }
 
     /**
      * Check for a hook file.
      *
      * @param  string $hook
+     *
      * @return bool
      */
-    public function hookExists($hook) : bool
+    public function hookExists($hook): bool
     {
-        return file_exists($this->getHooksDir() . DIRECTORY_SEPARATOR . $hook);
+        return file_exists($this->getHooksDir().DIRECTORY_SEPARATOR.$hook);
     }
 
     /**
@@ -118,11 +120,12 @@ class Repository
      *
      * @return \SebastianFeldmann\Git\CommitMessage
      */
-    public function getCommitMsg() : CommitMessage
+    public function getCommitMsg(): CommitMessage
     {
         if (null === $this->commitMsg) {
             throw new \RuntimeException('No commit message available');
         }
+
         return $this->commitMsg;
     }
 
@@ -131,13 +134,14 @@ class Repository
      *
      * @return bool
      */
-    public function isMerging() : bool
+    public function isMerging(): bool
     {
         foreach (['MERGE_MSG', 'MERGE_HEAD', 'MERGE_MODE'] as $fileName) {
-            if (file_exists($this->dotGitDir . DIRECTORY_SEPARATOR . $fileName)) {
+            if (file_exists($this->dotGitDir.DIRECTORY_SEPARATOR.$fileName)) {
                 return true;
             }
         }
+
         return false;
     }
 
@@ -146,7 +150,7 @@ class Repository
      *
      * @return \SebastianFeldmann\Git\Operator\Index
      */
-    public function getIndexOperator() : Operator\Index
+    public function getIndexOperator(): Operator\Index
     {
         return $this->getOperator('Index');
     }
@@ -156,7 +160,7 @@ class Repository
      *
      * @return \SebastianFeldmann\Git\Operator\Log
      */
-    public function getLogOperator() : Operator\Log
+    public function getLogOperator(): Operator\Log
     {
         return $this->getOperator('Log');
     }
@@ -165,14 +169,27 @@ class Repository
      * Return requested operator.
      *
      * @param  string $name
+     *
      * @return mixed
      */
     private function getOperator(string $name)
     {
         if (!isset($this->operator[$name])) {
-            $class                 = '\\SebastianFeldmann\\Git\\Operator\\' . $name;
+            $class = '\\SebastianFeldmann\\Git\\Operator\\'.$name;
             $this->operator[$name] = new $class($this->runner, $this);
         }
+
         return $this->operator[$name];
+    }
+
+
+    /**
+     * Get the repository configuration
+     *
+     * @return \SebastianFeldmann\Git\Operator\Config
+     */
+    public function getConfig(): Operator\Config
+    {
+        return $this->getOperator('Config');
     }
 }

--- a/tests/git/Command/Config/GetTest.php
+++ b/tests/git/Command/Config/GetTest.php
@@ -1,0 +1,34 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Git.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+namespace SebastianFeldmann\Git\Command\Log;
+
+use SebastianFeldmann\Git\Command\Config\Get;
+
+/**
+ * Class GetTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 0.9.0
+ */
+class GetTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Tests Commits::getCommand
+     */
+    public function testDefault()
+    {
+        $cmd = new Get();
+        $exe = $cmd->name('user.name')->getCommand();
+
+        $this->assertEquals('git config --get user.name', $exe);
+    }
+}

--- a/tests/git/Operator/ConfigTest.php
+++ b/tests/git/Operator/ConfigTest.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * This file is part of SebastianFeldmann\Cli.
+ *
+ * (c) Sebastian Feldmann <sf@sebastian-feldmann.info>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace SebastianFeldmann\Git\Operator;
+
+use SebastianFeldmann\Cli\Command\Result as CommandResult;
+use SebastianFeldmann\Cli\Command\Runner\Result as RunnerResult;
+
+/**
+ * Class ConfigTest
+ *
+ * @package SebastianFeldmann\Git
+ * @author  Sebastian Feldmann <sf@sebastian-feldmann.info>
+ * @link    https://github.com/sebastianfeldmann/git
+ * @since   Class available since Release 0.9.0
+ */
+class ConfigTest extends OperatorTest
+{
+    /**
+     * Tests ::getChangedFilesSince
+     */
+    public function testHas()
+    {
+        $repo = $this->getRepoMock();
+        $runner = $this->getRunnerMock();
+        $cmd = new CommandResult('git ...', 0);
+        $result = new RunnerResult($cmd);
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__.'/../../..'));
+        $runner->method('run')->willReturn($result);
+
+        $config = new Config($runner, $repo);
+        $hasKey = $config->has('core.commentchar');
+
+        $this->assertEquals(true, $hasKey);
+    }
+
+    /**
+     * Tests Log::getChangedFilesSince
+     */
+    public function testGetCommitsSince()
+    {
+        $repo = $this->getRepoMock();
+        $runner = $this->getRunnerMock();
+        $cmd = new CommandResult('git ...', 0);
+        $result = new RunnerResult($cmd);
+
+        $repo->method('getRoot')->willReturn(realpath(__FILE__.'/../../..'));
+        $runner->method('run')->willReturn($result);
+
+        $config = new Config($runner, $repo);
+        $value = $config->get('core.commentchar');
+
+        $this->assertEquals('#', $value);
+    }
+}


### PR DESCRIPTION
Currently there's no way to work out what a config variable should be
with git simply by reading text files. This is because the git exec
reads from different places depending on what prefix was during build.

This will allow us to use the binary to resovle that information.